### PR TITLE
util: use proper circular reference checking

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -612,10 +612,13 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
+  // TODO(addaleax): Make `seen` a Set to avoid linear-time lookup.
+  if (ctx.seen.includes(value)) {
+    return ctx.stylize('[Circular]', 'special');
+  }
+
   ctx.seen.push(value);
-
-  var output = formatter(ctx, value, recurseTimes, visibleKeys, keys);
-
+  const output = formatter(ctx, value, recurseTimes, visibleKeys, keys);
   ctx.seen.pop();
 
   return reduceToSingleString(output, base, braces, ctx.breakLength);
@@ -835,21 +838,17 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
   }
   if (!str) {
-    if (ctx.seen.indexOf(desc.value) < 0) {
-      if (recurseTimes === null) {
-        str = formatValue(ctx, desc.value, null);
-      } else {
-        str = formatValue(ctx, desc.value, recurseTimes - 1);
-      }
-      if (str.indexOf('\n') > -1) {
-        if (array) {
-          str = str.replace(/\n/g, '\n  ');
-        } else {
-          str = str.replace(/^|\n/g, '\n   ');
-        }
-      }
+    if (recurseTimes === null) {
+      str = formatValue(ctx, desc.value, null);
     } else {
-      str = ctx.stylize('[Circular]', 'special');
+      str = formatValue(ctx, desc.value, recurseTimes - 1);
+    }
+    if (str.indexOf('\n') > -1) {
+      if (array) {
+        str = str.replace(/\n/g, '\n  ');
+      } else {
+        str = str.replace(/^|\n/g, '\n   ');
+      }
     }
   }
   if (name === undefined) {


### PR DESCRIPTION
Circular references are conceptually nothing that should be checked
for objects (or Sets or Maps) only, but applies to recursive structures
in general, so move the `seen` checks into a position where it is part
of the recursion itself.

Fixes: https://github.com/with-git/node/issues/1
PR-URL: https://github.com/with-git/node/pull/2

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
